### PR TITLE
Changed the jumbotron height to 86vh.

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@
     }
 
 .jumbotron {
-    height: 80vh;
+    height: 86vh;
     background-size: cover;
     background: url('/img/ieee-right-hand-logo2\ -\ Copy.png');
     background-position: center;


### PR DESCRIPTION
Now the vision and mission blocks won't be peek at the main landing page after the animations have been viewed.