### PR TITLE
new nabar HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,30 +32,41 @@
     <button onclick="topFunction()" id="top" title="Back to top">
         <i style="size: 22px;" class="fa fa-angle-up"></i>
     </button>
-    <nav class="navbar sticky-top navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand" href="#">
-            <img src="img/ieeesb.jpg" height="50" width="100">
-        </a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
-            aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class=" navbar-nav navbar-right">
-                <li class="nav-item">
-                    <a class="nav-link" href="#">Home
-                        <span class="sr-only">(current)</span>
-                    </a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="#">Link</a>
-                </li>
-
-            </ul>
-
+    
+    <nav id="mainNavbar" class="navbar navbar-expand-md fixed-top">
+        <div class="container-fluid">
+                <a class="navbar-brand my-0 py-0" data-toggle="modal" data-target="#logoModal" href="#"><img src="imgs/ieeesb_transparent_logo.png" height="40px" id="brand_logo" alt="IEEE_GEC_logo"></a>
+                <button class="navbar-toggler" id="toggleButton" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                  <span class=""><i class="far fa-caret-square-down"></i></span>
+                </button>
+                <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                  <div class="navbar-nav mr-auto" id="darkBG">
+                    <a class="nav-link nav-item navbarLinks mx-2" id="" href="#"><i class="fas fa-home"></i> Home <span class="sr-only">(current)</span></a>               
+                    <a class="nav-link nav-item navbarLinks mx-2" href="#"><i class="fas fa-camera-retro"></i> Gallery</a>                    
+                    <a class="nav-link nav-item navbarLinks mx-2" href="#"><i class="fas fa-award"></i> Achievements</a>                        
+                    <a class="nav-link nav-item navbarLinks mx-2" href="#"><i class="fas fa-peace"></i> Placeholder</a>
+                  </div>
+                </div>
         </div>
     </nav>
+<script>
+    $(function() {
+	$(document).scroll(function() {
+		var $nav = $('#mainNavbar');
+		$nav.toggleClass('scrolled', $(this).scrollTop() > $nav.height()); // css/transition effect
+		$nav.toggleClass('bg-white', $(this).scrollTop() > $nav.height()); //Background
+		var $navbar_links = $('.navbarLinks');
+		$navbar_links.toggleClass('navbar_link', $(this).scrollTop() > $nav.height()); //hover effect
+		$('#toggleButton').click(function() {
+			var $clickButton = $('#mainNavbar ');
+			$clickButton.toggleClass('bg-white', $(this).scrollTop() < $nav.height()); //toggle dark nav when not scrolling past nav heigh
+		});
+	});
+});
+
+
+
+</script>
     <script>
         particlesJS.load('particles-js', 'kevin-custom-particles.json', function () {;
         });


### PR DESCRIPTION
This is the HTML for the new navbar as designed by Vipul. The kite icon't opacity has been reduced to 90%. There is enhancement of the particles.

Screenshots for reference:
Landing page:
![screenshot from 2019-03-07 21-49-29](https://user-images.githubusercontent.com/30661278/53972038-147ee780-4124-11e9-9dca-b68dd50f6e61.png)

On scrolling down:
![screenshot from 2019-03-07 21-49-34](https://user-images.githubusercontent.com/30661278/53972219-60ca2780-4124-11e9-8b45-3ac88c7f9756.png)

The navbar turns opaque on scrolling down the page. It is transparent at the top.
